### PR TITLE
feat: atomSignal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- feat: atomSignal #11
 
 ## [0.7.3] - 2023-01-25
 ### Changed

--- a/__tests__/01_basic_spec.tsx
+++ b/__tests__/01_basic_spec.tsx
@@ -1,9 +1,9 @@
-import { $, atomWithSignal, createElement } from '../src/index';
+import { $, atomSignal, createElement } from '../src/index';
 
 describe('basic spec', () => {
   it('should export functions', () => {
     expect($).toBeDefined();
-    expect(atomWithSignal).toBeDefined();
+    expect(atomSignal).toBeDefined();
     expect(createElement).toBeDefined();
   });
 });

--- a/__tests__/01_basic_spec.tsx
+++ b/__tests__/01_basic_spec.tsx
@@ -1,9 +1,10 @@
-import { $, getValueProp, createElement } from '../src/index';
+import { $, atomWithSignal, createElement, inject } from '../src/index';
 
 describe('basic spec', () => {
   it('should export functions', () => {
     expect($).toBeDefined();
-    expect(getValueProp).toBeDefined();
+    expect(atomWithSignal).toBeDefined();
     expect(createElement).toBeDefined();
+    expect(inject).toBeDefined();
   });
 });

--- a/__tests__/01_basic_spec.tsx
+++ b/__tests__/01_basic_spec.tsx
@@ -1,10 +1,9 @@
-import { $, atomWithSignal, createElement, inject } from '../src/index';
+import { $, atomWithSignal, createElement } from '../src/index';
 
 describe('basic spec', () => {
   it('should export functions', () => {
     expect($).toBeDefined();
     expect(atomWithSignal).toBeDefined();
     expect(createElement).toBeDefined();
-    expect(inject).toBeDefined();
   });
 });

--- a/examples/04_todos/src/App.tsx
+++ b/examples/04_todos/src/App.tsx
@@ -3,7 +3,7 @@
 import { memo } from 'react';
 import type { FormEvent } from 'react';
 import { atom } from 'jotai/vanilla';
-import { useAtom, useSetAtom } from 'jotai/react';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai/react';
 import type { PrimitiveAtom } from 'jotai/vanilla';
 import { $ } from 'jotai-signal';
 
@@ -42,7 +42,7 @@ const TodoItem = memo(({ todoAtom, remove }: TodoItemProps) => {
     <div style={{ backgroundColor: createRandomColor() }}>
       <input
         type="checkbox"
-        checked={$(todoAtom).completed}
+        checked={$(atom((get) => get(todoAtom).completed))}
         onChange={toggleCompleted}
       />
       <span
@@ -52,7 +52,7 @@ const TodoItem = memo(({ todoAtom, remove }: TodoItemProps) => {
           ),
         }}
       >
-        {$(todoAtom).title}
+        {$(atom((get) => get(todoAtom).title))}
       </span>
       <button type="button" onClick={() => remove(todoAtom)}>
         Remove
@@ -86,7 +86,7 @@ type FilteredProps = {
 };
 const Filtered = ({ remove }: FilteredProps) => (
   <div style={{ padding: 30, backgroundColor: createRandomColor() }}>
-    {$(filteredTodoAtomsAtom).map((todoAtom) => (
+    {useAtomValue(filteredTodoAtomsAtom).map((todoAtom) => (
       <TodoItem key={`${todoAtom}`} todoAtom={todoAtom} remove={remove} />
     ))}
   </div>

--- a/examples/07_atomsignal/package.json
+++ b/examples/07_atomsignal/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "jotai-signal-example",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "jotai": "latest",
+    "jotai-signal": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "react-scripts": "latest",
+    "typescript": "latest"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/07_atomsignal/public/index.html
+++ b/examples/07_atomsignal/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>jotai-signal example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/07_atomsignal/src/App.tsx
+++ b/examples/07_atomsignal/src/App.tsx
@@ -1,13 +1,13 @@
 import jsxRuntime from 'react/jsx-runtime';
 import { useSetAtom } from 'jotai/react';
-import { atomWithSignal } from 'jotai-signal';
+import { atomSignal } from 'jotai-signal';
 import { jsx, jsxs } from 'jotai-signal/jsx-runtime';
 
 (jsxRuntime as any).jsx = jsx;
 (jsxRuntime as any).jsxs = jsxs;
 
-const count = atomWithSignal(0);
-const doubled = atomWithSignal((get: any) => get(count) * 2);
+const count = atomSignal(0);
+const doubled = atomSignal((get) => get(count) * 2);
 
 const CounterWithSignal = () => {
   return (
@@ -25,7 +25,7 @@ const Controls = () => {
   const setCount = useSetAtom(count);
   return (
     <div>
-      <button type="button" onClick={() => setCount((c: any) => c + 1)}>
+      <button type="button" onClick={() => setCount((c) => c + 1)}>
         Increment
       </button>
     </div>

--- a/examples/07_atomsignal/src/App.tsx
+++ b/examples/07_atomsignal/src/App.tsx
@@ -1,35 +1,8 @@
-/** @jsxImportSource jotai-signal */
-
-import { atom } from 'jotai/vanilla';
+import React from 'react';
 import { useSetAtom } from 'jotai/react';
-import { $ as signal } from 'jotai-signal';
+import { atomWithSignal, inject } from 'jotai-signal';
 
-// Typing this is too hard...
-const atomWithSignal = (read: any, write?: any, store?: any) => {
-  const a = atom(read, write);
-  const s = signal(a, store);
-  return new Proxy(
-    (() => {
-      // empty
-    }) as any,
-    {
-      get(_target, prop) {
-        if (prop in a) {
-          return (a as any)[prop];
-        }
-        return (s as any)[prop];
-      },
-      has(_target, prop) {
-        if (prop in a) {
-          return true;
-        }
-        return prop in s;
-      },
-    },
-  );
-};
-
-// -----------------------------------------------
+React.createElement = inject(React.createElement);
 
 const count = atomWithSignal(0);
 const doubled = atomWithSignal((get: any) => get(count) * 2);

--- a/examples/07_atomsignal/src/App.tsx
+++ b/examples/07_atomsignal/src/App.tsx
@@ -3,6 +3,7 @@ import { useSetAtom } from 'jotai/react';
 import { atomSignal } from 'jotai-signal';
 import { jsx, jsxs } from 'jotai-signal/jsx-runtime';
 
+// This hack only works if jsxRuntime is CJS not ESM.
 (jsxRuntime as any).jsx = jsx;
 (jsxRuntime as any).jsxs = jsxs;
 

--- a/examples/07_atomsignal/src/App.tsx
+++ b/examples/07_atomsignal/src/App.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import jsxRuntime from 'react/jsx-runtime';
 import { useSetAtom } from 'jotai/react';
-import { atomWithSignal, inject } from 'jotai-signal';
+import { atomWithSignal } from 'jotai-signal';
+import { jsx, jsxs } from 'jotai-signal/jsx-runtime';
 
-React.createElement = inject(React.createElement);
+(jsxRuntime as any).jsx = jsx;
+(jsxRuntime as any).jsxs = jsxs;
 
 const count = atomWithSignal(0);
 const doubled = atomWithSignal((get: any) => get(count) * 2);

--- a/examples/07_atomsignal/src/App.tsx
+++ b/examples/07_atomsignal/src/App.tsx
@@ -1,0 +1,67 @@
+/** @jsxImportSource jotai-signal */
+
+import { atom } from 'jotai/vanilla';
+import { useSetAtom } from 'jotai/react';
+import { $ as signal } from 'jotai-signal';
+
+// Typing this is too hard...
+const atomWithSignal = (read: any, write?: any, store?: any) => {
+  const a = atom(read, write);
+  const s = signal(a, store);
+  return new Proxy(
+    (() => {
+      // empty
+    }) as any,
+    {
+      get(_target, prop) {
+        if (prop in a) {
+          return (a as any)[prop];
+        }
+        return (s as any)[prop];
+      },
+      has(_target, prop) {
+        if (prop in a) {
+          return true;
+        }
+        return prop in s;
+      },
+    },
+  );
+};
+
+// -----------------------------------------------
+
+const count = atomWithSignal(0);
+const doubled = atomWithSignal((get: any) => get(count) * 2);
+
+const CounterWithSignal = () => {
+  return (
+    <>
+      <h1>With $(atom)</h1>
+      <p>
+        Count: {count} ({Math.random()})
+      </p>
+      <p>Doubled: {doubled}</p>
+    </>
+  );
+};
+
+const Controls = () => {
+  const setCount = useSetAtom(count);
+  return (
+    <div>
+      <button type="button" onClick={() => setCount((c: any) => c + 1)}>
+        Increment
+      </button>
+    </div>
+  );
+};
+
+const App = () => (
+  <>
+    <Controls />
+    <CounterWithSignal />
+  </>
+);
+
+export default App;

--- a/examples/07_atomsignal/src/index.tsx
+++ b/examples/07_atomsignal/src/index.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+
+const ele = document.getElementById('app');
+if (ele) {
+  createRoot(ele).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}

--- a/examples/07_atomsignal/tsconfig.json
+++ b/examples/07_atomsignal/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "examples:03_async": "DIR=03_async EXT=tsx webpack serve",
     "examples:04_todos": "DIR=04_todos EXT=tsx webpack serve",
     "examples:05_setvalue": "DIR=05_setvalue EXT=tsx webpack serve",
-    "examples:06_showhide": "DIR=06_showhide EXT=tsx webpack serve"
+    "examples:06_showhide": "DIR=06_showhide EXT=tsx webpack serve",
+    "examples:07_atomsignal": "DIR=07_atomsignal EXT=tsx webpack serve"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "create-react-signals": "https://pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals"
+    "create-react-signals": "0.7.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "create-react-signals": "0.6.2"
+    "create-react-signals": "https://pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ specifiers:
   '@types/react-dom': ^18.0.10
   '@typescript-eslint/eslint-plugin': ^5.49.0
   '@typescript-eslint/parser': ^5.49.0
-  create-react-signals: 0.6.2
+  create-react-signals: https://pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals
   eslint: ^8.32.0
   eslint-config-airbnb: ^19.0.4
   eslint-config-prettier: ^8.6.0
@@ -32,7 +32,7 @@ specifiers:
   webpack-dev-server: ^4.11.1
 
 dependencies:
-  create-react-signals: 0.6.2_react@18.2.0
+  create-react-signals: '@pkg.csb.dev/dai-shi/create-react-signals/commit/0552036f/create-react-signals_react@18.2.0'
 
 devDependencies:
   '@types/jest': 29.4.0
@@ -3173,14 +3173,6 @@ packages:
       path-type: 4.0.0
       yaml: 1.10.2
     dev: true
-
-  /create-react-signals/0.6.2_react@18.2.0:
-    resolution: {integrity: sha512-p+I3k2LbTaZapE/ZYhCPi4P+n4TljdqiT6Q6y+qVKwLels2FNywlck8mrx94AgcMK+WmQliywzDAZ1woQtOL9g==}
-    peerDependencies:
-      react: '>=17.0.0'
-    dependencies:
-      react: 18.2.0
-    dev: false
 
   /cross-spawn/6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
@@ -8487,3 +8479,14 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  '@pkg.csb.dev/dai-shi/create-react-signals/commit/0552036f/create-react-signals_react@18.2.0':
+    resolution: {tarball: https://pkg.csb.dev/dai-shi/create-react-signals/commit/0552036f/create-react-signals}
+    id: '@pkg.csb.dev/dai-shi/create-react-signals/commit/0552036f/create-react-signals'
+    name: create-react-signals
+    version: 0.6.2
+    peerDependencies:
+      react: '>=17.0.0'
+    dependencies:
+      react: 18.2.0
+    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ specifiers:
   webpack-dev-server: ^4.11.1
 
 dependencies:
-  create-react-signals: '@pkg.csb.dev/dai-shi/create-react-signals/commit/0552036f/create-react-signals_react@18.2.0'
+  create-react-signals: '@pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals_react@18.2.0'
 
 devDependencies:
   '@types/jest': 29.4.0
@@ -8480,11 +8480,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  '@pkg.csb.dev/dai-shi/create-react-signals/commit/0552036f/create-react-signals_react@18.2.0':
-    resolution: {tarball: https://pkg.csb.dev/dai-shi/create-react-signals/commit/0552036f/create-react-signals}
-    id: '@pkg.csb.dev/dai-shi/create-react-signals/commit/0552036f/create-react-signals'
+  '@pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals_react@18.2.0':
+    resolution: {tarball: https://pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals}
+    id: '@pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals'
     name: create-react-signals
-    version: 0.6.2
+    version: 0.7.0-wip.0
     peerDependencies:
       react: '>=17.0.0'
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ specifiers:
   '@types/react-dom': ^18.0.10
   '@typescript-eslint/eslint-plugin': ^5.49.0
   '@typescript-eslint/parser': ^5.49.0
-  create-react-signals: https://pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals
+  create-react-signals: 0.7.0
   eslint: ^8.32.0
   eslint-config-airbnb: ^19.0.4
   eslint-config-prettier: ^8.6.0
@@ -32,7 +32,7 @@ specifiers:
   webpack-dev-server: ^4.11.1
 
 dependencies:
-  create-react-signals: '@pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals_react@18.2.0'
+  create-react-signals: 0.7.0_react@18.2.0
 
 devDependencies:
   '@types/jest': 29.4.0
@@ -3173,6 +3173,14 @@ packages:
       path-type: 4.0.0
       yaml: 1.10.2
     dev: true
+
+  /create-react-signals/0.7.0_react@18.2.0:
+    resolution: {integrity: sha512-DZmZTMExl9nyX/5PUTsPxw7w9HuI538h5ppxp85JXs/SMgABqDGJ5dVtuM0MLDVWyUmJZMx92f8QTnn3fP7yig==}
+    peerDependencies:
+      react: '>=17.0.0'
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /cross-spawn/6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
@@ -8479,14 +8487,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-  '@pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals_react@18.2.0':
-    resolution: {tarball: https://pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals}
-    id: '@pkg.csb.dev/dai-shi/create-react-signals/commit/cf9c93cf/create-react-signals'
-    name: create-react-signals
-    version: 0.7.0-wip.0
-    peerDependencies:
-      react: '>=17.0.0'
-    dependencies:
-      react: 18.2.0
-    dev: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { $, getValueProp, createElement } from './signal';
+export { $, atomWithSignal, createElement, inject } from './signal';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { $, atomWithSignal, createElement } from './signal';
+export { $, atomSignal, createElement } from './signal';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { $, atomWithSignal, createElement, inject } from './signal';
+export { $, atomWithSignal, createElement } from './signal';

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -11,4 +11,3 @@ export const jsx = (type: any, props: any, key: any) => {
 };
 
 export const jsxs = jsx;
-export const jsxDEV = jsx;

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -96,8 +96,6 @@ const { getSignal, inject } = createReactSignals(
   use,
 );
 
-export { inject };
-
 export const createElement = inject(ReactExports.createElement);
 
 type AttachValue<T> = T & { value: T };

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -111,21 +111,21 @@ export function $<T>(anAtom: Atom<T>, store = getDefaultStore()) {
   return getSignal(anAtom, store);
 }
 
-// atomWithSignal util
+// atomSignal util
 
-export function atomWithSignal<Value, Args extends unknown[], Result>(
+export function atomSignal<Value, Args extends unknown[], Result>(
   read: Read<Value, SetAtom<Args, Result>>,
   write: Write<Args, Result>,
   store?: Store,
 ): WritableAtom<Value, Args, Result> &
   (Value extends Primitives ? AttachValue<Value> : never);
 
-export function atomWithSignal<Value>(
+export function atomSignal<Value>(
   read: Read<Value>,
   store?: Store,
 ): Atom<Value> & (Value extends Primitives ? AttachValue<Value> : never);
 
-export function atomWithSignal<Value, Args extends unknown[], Result>(
+export function atomSignal<Value, Args extends unknown[], Result>(
   initialValue: Value,
   write: Write<Args, Result>,
   store?: Store,
@@ -133,7 +133,7 @@ export function atomWithSignal<Value, Args extends unknown[], Result>(
   WithInitialValue<Value> &
   (Value extends Primitives ? AttachValue<Value> : never);
 
-export function atomWithSignal<Value>(
+export function atomSignal<Value>(
   initialValue: Value,
   write?: never,
   store?: Store,
@@ -141,8 +141,8 @@ export function atomWithSignal<Value>(
   WithInitialValue<Value> &
   (Value extends Primitives ? AttachValue<Value> : never);
 
-export function atomWithSignal(read: any, write?: any, store?: any) {
-  const a = atom(read, write);
-  const s = $(a as any, store);
-  return Object.assign(s, a) as any;
+export function atomSignal(read: any, write?: any, store?: any) {
+  const anAtom = atom(read, write);
+  const aSignal = $(anAtom as any, store);
+  return Object.assign(aSignal, anAtom) as any;
 }


### PR DESCRIPTION
- update create-react-signals
- only support primitives for signals
- new atomSignal util
- examples/07 with jsx inject