### PR TITLE
fix(jsx-runtime): revert jsxDEV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- fix(jsx-runtime): revert jsxDEV #12
 
 ## [0.8.0] - 2023-02-25
 ### Added

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -11,3 +11,4 @@ export const jsx = (type: any, props: any, key: any) => {
 };
 
 export const jsxs = jsx;
+export const jsxDEV = jsx;


### PR DESCRIPTION
In #11, I removed `jsxDEV` forgetting that it's used as jsx-dev-runtime.